### PR TITLE
using relative path instead

### DIFF
--- a/doc/Win_install/reserve_neng.bat
+++ b/doc/Win_install/reserve_neng.bat
@@ -1,5 +1,5 @@
 rem reserve wallet only, not for mining
 rem mining wallet can go bad quickly, recommend to transfer your mined coin to this reserve wallet daily
 rem change below username to your proper username
-nengcoin-qt.exe  -port=8377  -rpcport=8376 -datadir=C:\Users\hongl\AppData\Roaming\Nengcoin2
+nengcoin-qt.exe  -port=8377  -rpcport=8376 -datadir=%HOMEPATH%\AppData\Roaming\Nengcoin2
 pause


### PR DESCRIPTION
%HOMEPATH% is a relative path for C:\user\<current user> so it must be nice to use instead of a current one.